### PR TITLE
Fix that the logo animation is stopped after dismissing the share screen

### DIFF
--- a/app/src/main/java/au/gov/health/covidsafe/ui/home/HomeFragment.kt
+++ b/app/src/main/java/au/gov/health/covidsafe/ui/home/HomeFragment.kt
@@ -200,6 +200,7 @@ class HomeFragment : BaseFragment(), EasyPermissions.PermissionCallbacks {
 
             if (isAllPermissionsEnabled) {
                 home_header_picture_setup_complete.setAnimation("spinner_home.json")
+                home_header_picture_setup_complete.resumeAnimation()
                 content_setup_incomplete_group.visibility = GONE
                 ContextCompat.getColor(it, R.color.lighter_green).let { bgColor ->
                     header_background.setBackgroundColor(bgColor)


### PR DESCRIPTION
Hi, thanks for publishing this great app and its source code!

Quite nitpicking but I noticed that the logo animation is stopped when I dismissed the share screen.

This might be Lottie's bug since this is happening even `autoPlay=true` is set. Please feel free to close this pull request if you know a better solution.

| Before | After |
|--|--|
|![Screen Recording 2020-06-20 at 1 33 32 pm](https://user-images.githubusercontent.com/1333214/85190531-96385b80-b2fc-11ea-8534-eab698916813.gif)|![Screen Recording 2020-06-20 at 1 32 06 pm](https://user-images.githubusercontent.com/1333214/85190540-acdeb280-b2fc-11ea-9ce1-7cfa51e8c536.gif)|

## Environments where I reproduced

- App Version: 1.0.28
- Devices: 
    - [Emulator] Pixel 3 API 29
    - [Physical Device] OnePlus6T Oxygen OS 10.3.4 (Android 10)
