### PR TITLE
Testing a proof-of-concept fix for the duplicate GATT service issue.

### DIFF
--- a/app/src/main/java/au/gov/health/covidsafe/sensor/ble/ConcreteBLETransmitter.kt
+++ b/app/src/main/java/au/gov/health/covidsafe/sensor/ble/ConcreteBLETransmitter.kt
@@ -81,10 +81,20 @@ class ConcreteBLETransmitter(
         override fun bleTimer(now: Long) {
             if (!isSupported || bluetoothStateManager.state() == BluetoothState.poweredOff) {
                 if (advertLoopState != AdvertLoopState.stopped) {
+                    // [AT] Clear services and close GATT server, if it exists
+                    try {
+                        if (bluetoothGattServer != null) {
+                            logger.debug("[AT] bleTimer, non-null gatt server, stopping GATT server")
+                            bluetoothGattServer!!.clearServices()
+                            bluetoothGattServer!!.close()
+                        }
+                    } catch (e: Throwable) {
+                        logger.fault("[AT] bleTimer, failed to stop GATT server", e)
+                    }
                     advertiseCallback = null
                     bluetoothGattServer = null
                     state(now, AdvertLoopState.stopped)
-                    logger.debug("advertLoopTask, stop advert (advert={}ms)", timeSincelastStateChange(now))
+                    logger.debug("[AT] advertLoopTask, BluetoothState.powerdOff, stop advert (advert={}ms)", timeSincelastStateChange(now))
                 }
                 return
             }

--- a/app/src/main/java/au/gov/health/covidsafe/services/BluetoothMonitoringService.kt
+++ b/app/src/main/java/au/gov/health/covidsafe/services/BluetoothMonitoringService.kt
@@ -11,6 +11,7 @@ import android.content.IntentFilter
 import android.location.LocationManager
 import android.os.Build
 import android.os.PowerManager
+import android.util.Log
 import androidx.annotation.Keep
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.LifecycleService
@@ -93,12 +94,16 @@ class BluetoothMonitoringService : LifecycleService(), CoroutineScope, SensorDel
     }
 
     fun teardown() {
-        commandHandler.removeCallbacksAndMessages(null)
+        //commandHandler.removeCallbacksAndMessages(null)
 
-        Utils.cancelBMUpdateCheck(this.applicationContext)
-        Utils.cancelNextScan(this.applicationContext)
-        Utils.cancelNextAdvertise(this.applicationContext)
-        sensor?.stop()
+        //Utils.cancelBMUpdateCheck(this.applicationContext)
+        //Utils.cancelNextScan(this.applicationContext)
+        //Utils.cancelNextAdvertise(this.applicationContext)
+
+        //[AT]
+        Log.i(TAG, "[AT] teardown, do nothing")
+
+        //sensor?.stop()
     }
 
     private fun setupNotifications() {
@@ -263,8 +268,15 @@ class BluetoothMonitoringService : LifecycleService(), CoroutineScope, SensorDel
     }
 
     fun sensorStart() {
-        if (broadcastMessage != null) {
+        // [AT] Don't create a new sensor, to avoid creating multiple advertisements/duplicate GATT services
+        Log.i(TAG, "[AT] sensorStart")
+
+        if (broadcastMessage != null && sensor == null) {
+
             streetPassRecordStorage = StreetPassRecordStorage(applicationContext)
+
+            Log.i(TAG, "[AT] creating a new SensorArray")
+
             sensor = SensorArray(applicationContext, this)
             getAppDelegate().sensor()?.add(this)
             // Sensor will start and stop with Bluetooth power on / off events


### PR DESCRIPTION
This is related to Issue #33  (duplicate GATT service registered). I think there are two separate issues:
- bluetoothGattServer in AdvertLoopTask is not closed properly when bluetooth adapter is powered off. It seems that in some phone models, the GATT server is not automatically closed when bluetooth is powered off. This was consistently observed in Samsung phones. 
- multiple SensorArray objects are created, in BluetoothMonitoringService, when bluetooth is powered off and on. This leads to a new instance of ConcreteBLETransmitter being created each time bluetooth is powered off/on. 

The modifications I did: 
- In ConcreteBLETransmitter.kt, make sure services are cleard and GATT server closed (if it exists)
- In BluetoothMonitoringService.kt, make sure no duplicate SensorArray objects are created.

DISCLAIMER: This modification is meant to demonstrate a diagnosis of the root cause of the issue; it is not meant as a definitive fix. Further tests will be required. 

